### PR TITLE
Parallelize card definitions loading

### DIFF
--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -10,7 +10,8 @@
             [web.game :as game]
             [web.stats :as stats]
             [jinteki.nav :as nav]
-            [clj-time.format :as f])
+            [clj-time.format :as f]
+            [game.core :as core])
   (:gen-class :main true))
 
 (defonce server (atom nil))
@@ -32,6 +33,7 @@
                        (map (fn [e] (update e :date_start #(f/parse (f/formatters :date) %))))
                        (sort-by :date_start)
                        (last))]
+      (core/init-once)
       (reset! cards/all-cards (into {} (map (juxt :title identity)
                                             (sort-by (complement :rotated) cards))))
       (reset! cards/sets sets)

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -51,6 +51,7 @@
 
 
 (defn load-all-cards [tests]
+  (core/init-once)
   (when (empty? @all-cards)
     (reset! all-cards (into {} (map (juxt :title identity) (map #(assoc % :cid (make-cid)) (load-cards))))))
   (tests))


### PR DESCRIPTION
Hi there,

This PR implements parallel card definitions loading.

In particular,
`load-all-cards` now loads card definitions in parallel. This should reduce time spent loading data.
`init-once` can be called to load the definitions and set the 'game.core/cards var.